### PR TITLE
Make `print` statement Python 3 friendly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,13 @@
 language: python
 python:
-  - "2.7"
+  - 2.7
+  - 3.6
+# This part is necessary due to travis-ci/travis-ci#9815.
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: true
 
 script:
   - "python setup.py test"

--- a/mobbage/__init__.py
+++ b/mobbage/__init__.py
@@ -679,11 +679,12 @@ def main():
 
             # Print our verbose output if requested
             if args.verbose:
-                print "Code: {}, Size: {}, Time: {:d}ms, URL: {}".format(
+                print("Code: {}, Size: {}, Time: {:d}ms, URL: {}".format(
                     result.code,
                     bytes_to_human(result.size),
                     int(result.time*1000),
                     result.url)
+                )
 
             if result.error:
                 num_errors += 1


### PR DESCRIPTION
# Issue
Mobbage is published for Python 2 and Python 3, but v0.2 is broken for Python 3.

Reproduction:
1. `$ mobbage -n 100 http://localhost/`

Expected: a successful Mobbage run.

Actual (in a Python 2 environment):
```
Starting mobbage with 1 worker.
Results:
.
.
.
```

Actual (in a Python 3 environment):
```
Traceback (most recent call last):
  File "/Users/davidalber/.pyenv/versions/mobt3/bin/mobbage", line 7, in <module>
    from mobbage import main
  File "/Users/davidalber/.pyenv/versions/3.7.0/envs/mobt3/lib/python3.7/site-packages/mobbage/__init__.py", line 681
    print "Code: {}, Size: {}, Time: {:d}ms, URL: {}".format(
                                                    ^
SyntaxError: invalid syntax
```

# PR
This PR fixes the issue above by using Python 3 `print` syntax in the location that failed. Also, Python 3.6 and 3.7 are added to the CI build.