### PR TITLE
Modify headers command-line switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Command-line options can be grouped into these categories:
                              with -f
     -m str, --method str     HTTP method to use. Default is 'GET'
     -a str, --agent str      Set User-Agent request header
-    -H str, --headers str    Send request headers in 'name:value' format. Specify
+    -H str, --header str     Send request header in 'name:value' format. Specify
                              more than once for multiple headers
     -u str, --upload str     Upload a file via multipart/form-data POST. Must be
                              formatted as 'form_var:file_path[:content_type]'.
@@ -106,7 +106,7 @@ in the job objects are:
  * delay
  * method
  * agent
- * headers
+ * header
  * upload 
  * insecure
  * nokeepalive
@@ -114,13 +114,13 @@ in the job objects are:
  * authtype
 
 Options not specified in a job object will inherit values set on the command 
-line, and default values otherwise.  The "headers" and "upload" should be 
+line, and default values otherwise.  The "header" and "upload" should be
 specified as JSON arrays of strings.
 
 ### Example file format:
     [
         { "url": "http://www.foo.com", "count": 100,
-          "headers": ["host:www.bar.com", "accept-language:en-us"] },
+          "header": ["host:www.bar.com", "accept-language:en-us"] },
         { "url": "http://www.google.com/search?q=lmgtfy",
           "agent": "lulzBot/0.1", "delay": 50 },
         { "url": "http://www.bar.com", "method": "POST",

--- a/mobbage/__init__.py
+++ b/mobbage/__init__.py
@@ -43,7 +43,7 @@ def get_args():
         'The job file is a JSON formatted array of objects, with each object',
         'representing a single URL to test.  Options that are honored in the',
         'job objects are:' ,
-        '    url, method, agent, headers, upload, insecure, nokeepalive,',
+        '    url, method, agent, header, upload, insecure, nokeepalive,',
         '    num, delay\n',
         'Options not specified in a job object will inherit values set on',
         'the command line, and default values otherwise. The "header" and',
@@ -51,7 +51,7 @@ def get_args():
         'Example file contents:',
         '  [',
         '      { "url": "http://www.foo.com", "count": 100,',
-        '        "headers": ["host:www.bar.com", "accept-language:en-us"] },',
+        '        "header": ["host:www.bar.com", "accept-language:en-us"] },',
         '      { "url": "http://www.google.com/search?q=lmgtfy",',
         '        "agent": "lulzBot/0.1", "delay": 50 },',
         '      { "url": "http://www.bar.com", "method": "POST",',
@@ -82,8 +82,8 @@ def get_args():
     group1.add_argument("-a", "--agent", metavar="str", 
         default="mobbage/{}".format(VERSION),
         help="Set User-Agent request header")
-    group1.add_argument("-H", "--headers", metavar="str", action="append",
-        default=[], help="""Send request headers in 'name:value' format. 
+    group1.add_argument("-H", "--header", metavar="str", action="append",
+        default=[], help="""Send request header in 'name:value' format.
           Specify more than once for multiple headers""")
     group1.add_argument("-u", "--upload", metavar="str", action="append",
         default=[],  help="""Upload a file via multipart/form-data POST. 
@@ -309,9 +309,9 @@ class WorkerQueue():
         if "headers" in job:
             if not isinstance(job.headers, list):
                 raise Exception("Headers must be in list form")
-            header_list = job.headers + args.headers
+            header_list = job.headers + args.header
         else:
-            header_list = args.headers
+            header_list = args.header
 
         # Convert our list of colon-delimited k:v pairs to a dict
         header_dict = {}

--- a/mobbage/__init__.py
+++ b/mobbage/__init__.py
@@ -15,7 +15,6 @@ import socket
 import sys
 import threading
 import time
-import string
 
 VERSION=get_version(root="..", relative_to=__file__)
 
@@ -317,7 +316,7 @@ class WorkerQueue():
         header_dict = {}
         for kv in header_list:
             try:
-                key, val = map(string.strip, kv.split(':'))
+                key, val = [s.strip() for s in kv.split(':')]
                 header_dict[key.lower()] = val 
             except:
                 raise Exception(


### PR DESCRIPTION
This PR addresses the feedback in #2 by:
- Changing the switch name from "headers" to "header".
- Using a list comprehension to avoid an additional line for an import used by one other line.

#2 fixed a bug in the `--header` switch. This PR maintains that fix:
```
$ mobbage http://localhost:8080 -H foo:bar
Starting mobbage with 1 worker.
.
.
.
```

The important thing above is that the command did not fail with the error documented in #2.